### PR TITLE
fix profileskills disappearing when editing profile skills

### DIFF
--- a/src/store/modules/profiles/mutations.js
+++ b/src/store/modules/profiles/mutations.js
@@ -20,12 +20,8 @@ export const mutations = {
     Vue.set(state.profileSkills, profileSkill.id, profileSkill)
   },
   [types.UPDATE_PROFILE_SKILL] (state, profileSkill) {
-    // TODO: this might be wise to refactor
-    state.profileSkills = state.profileSkills.filter((skill) => {
-      return skill.id !== profileSkill.id
-    })
-    Vue.set(state.profileSkills, profileSkill.id, profileSkill)
-    state.profileSkills.sort((a, b) => { return a.id - b.id })
+    const profileSkillIndex = state.profileSkills.findIndex(skill => profileSkill.id === skill.id)
+    Vue.set(state.profileSkills, profileSkillIndex, profileSkill)
   },
   [types.REMOVE_PROFILE_SKILL] (state, profileSkillId) {
     state.profileSkills = state.profileSkills.filter((skill) => {

--- a/src/store/modules/profiles/mutations.js
+++ b/src/store/modules/profiles/mutations.js
@@ -17,7 +17,7 @@ export const mutations = {
     state.profileSkills = profileSkills
   },
   [types.ADD_PROFILE_SKILL] (state, profileSkill) {
-    Vue.set(state.profileSkills, profileSkill.id, profileSkill)
+    state.profileSkills.push(profileSkill)
   },
   [types.UPDATE_PROFILE_SKILL] (state, profileSkill) {
     const profileSkillIndex = state.profileSkills.findIndex(skill => profileSkill.id === skill.id)


### PR DESCRIPTION
call of Vue.set used to refer to id of the skill object, instead of referring to array index of the object.
now it refers to the correct object via its index in the array and the behaviour is correct